### PR TITLE
Fix deployment launcher

### DIFF
--- a/DeploymentManager/AuthenticationService/WorkerAuthenticator.cs
+++ b/DeploymentManager/AuthenticationService/WorkerAuthenticator.cs
@@ -26,7 +26,7 @@ namespace DeploymentManager
                     ProjectName = projectName,
                 };
 
-                return PlayerAuthServiceClient.CreateDevelopmentAuthenticationToken(request).DevelopmentAuthenticationToken.Id;
+                return PlayerAuthServiceClient.CreateDevelopmentAuthenticationToken(request).TokenSecret;
             });
         }
     }

--- a/DeploymentManager/DeploymentManager.csproj
+++ b/DeploymentManager/DeploymentManager.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
@@ -26,6 +26,6 @@
     <PackageReference Include="Improbable.CoreSdk" Version="13.5.0" />
     <PackageReference Include="Mono.Options" Version="5.3.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="Improbable.SpatialOS.Platform" Version="13.5.1" />
+    <PackageReference Include="Improbable.SpatialOS.Platform" Version="13.8.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The token ID is deprecated. We need to use the secret instead. This was rolled out to the backend service which can now reject your request if you still use the ID.

The deployment launcher failed to run when doing Unity release QA. This fixes it 🎉 