### PR TITLE
Reduce chance of race when adding tags

### DIFF
--- a/DeploymentManager/DeploymentService/DeploymentModifier.cs
+++ b/DeploymentManager/DeploymentService/DeploymentModifier.cs
@@ -124,6 +124,24 @@ namespace DeploymentManager
             });
         }
 
+        public static void AddDeploymentTags(GetDeploymentRequest request, IEnumerable<string> tags)
+        {
+            ExceptionHandler.HandleGrpcCall(() =>
+            {
+                var deployment = GetDeployment(request);
+
+                foreach (var tag in tags)
+                {
+                    if (!deployment.Tag.Contains(tag))
+                    {
+                        deployment.Tag.Add(tag);
+                    }
+                }
+                
+                UpdateDeployment(deployment);
+            });
+        }
+
         public static void AddDeploymentTag(GetDeploymentRequest request, string tag)
         {
             ExceptionHandler.HandleGrpcCall(() =>

--- a/DeploymentManager/Worker/DeploymentManager.cs
+++ b/DeploymentManager/Worker/DeploymentManager.cs
@@ -168,13 +168,8 @@ namespace DeploymentManager
         private void ConnectToDeployment(Deployment deployment)
         {
             var request = DeploymentModifier.GetGetDeploymentRequest(deployment.Id, workerConfig.ProjectName);
-            foreach (var deploymentTag in sessionConfig.DeploymentTags)
-            {
-                DeploymentModifier.AddDeploymentTag(request, deploymentTag);
-            }
-            
+            DeploymentModifier.AddDeploymentTags(request, sessionConfig.DeploymentTags.Append($"{Tags.MaxPlayers}_{sessionConfig.MaxNumberOfClients}"));
             DeploymentModifier.SetMaxWorkerCapacity(request, sessionConfig.ClientType, sessionConfig.MaxNumberOfClients);
-            DeploymentModifier.AddDeploymentTag(request, $"{Tags.MaxPlayers}_{sessionConfig.MaxNumberOfClients}");
 
             var connector = new Connector(WorkerType, deployment.Name, serviceConnection);
             var connectionParameters = new ConnectionParameters


### PR DESCRIPTION
Deployment manager seemed to start being racey where subsequent tag operations would fail if the deployment wasn't updated with the first change by the time you attempt the second change.

This PR seeks to reduce the chance of races by batching the tag operations. We really should be batching as much Platform SDK calls as much as possible, but that's a bit of a scope creep